### PR TITLE
JavaScript Primerを読んで覚えたことをJestを使って学習用テストとして残す

### DIFF
--- a/spec/array.spec.js
+++ b/spec/array.spec.js
@@ -1,0 +1,24 @@
+/*
+ * Arrayクラスの挙動を覚える
+ */
+
+describe('Array', () => {
+  describe('Arrayのリテラル記法とArray.prototype.atの挙動の違いを検証する', () => {
+    const array = ['a', 'b', 'c'];
+
+    it('0番目の要素を取得できる', () => {
+      expect(array[0]).toBe('a');
+      expect(array.at(0)).toBe('a');
+    });
+
+    it('リテラル記法だと末尾の要素を取得できず、Array.prototype.atなら取得できる', () => {
+      expect(array[-1]).toBe(undefined);
+      expect(array.at(-1)).toBe('c');
+    });
+
+    it('存在しないインデックスを指定して要素を取得しようとするとundefinedを返す', () => {
+      expect(array[100]).toBe(undefined);
+      expect(array.at(100)).toBe(undefined);
+    });
+  });
+});

--- a/spec/function.spec.js
+++ b/spec/function.spec.js
@@ -1,0 +1,18 @@
+describe('function', () => {
+  it('function演算子を使った定義', () => {
+    const function_name = function() {}
+    expect(typeof(function_name)).toEqual('function');
+  });
+
+  it('アロー関数', () => {
+    const function_name = () => {}
+    expect(typeof(function_name)).toEqual('function');
+  });
+
+  it('無名関数', () => {
+    expect(typeof(()=>{})).toEqual('function');
+    expect(typeof((x)=>{})).toEqual('function');
+    expect(typeof(x=>{})).toEqual('function');
+    expect(typeof(x=>x+x).toEqual('function');
+  });
+});

--- a/spec/object.spec.js
+++ b/spec/object.spec.js
@@ -1,0 +1,14 @@
+describe('Object', () => {
+  describe('メンバーの定義方法', () => {
+    it('メソッド', () => {
+      const obj = {
+        method1: function(){},
+        method2: () => {},
+        method3() {}
+      }
+      expect(typeof(obj.method1)).toEqual('function');
+      expect(typeof(obj.method2)).toEqual('function');
+      expect(typeof(obj.method3)).toEqual('function');
+    });
+  });
+});

--- a/spec/prototype.spec.js
+++ b/spec/prototype.spec.js
@@ -1,0 +1,20 @@
+/*
+ * プロトタイプオブジェクトの挙動を覚える
+ */
+
+describe('Object.prototype', () => {
+  it('プロトタイプオブジェクトにnameメソッドが追加されたことを検証する', () => {
+    const my_object = {}
+    expect(my_object.name).toBe(undefined);
+
+    // my_objectオブジェクトにnameメソッドを定義
+    my_object.name = () => { return 'まいおぶじぇくと' };
+    expect(my_object.name()).toBe('まいおぶじぇくと');
+
+    // my_objectオブジェクトをプロトタイプオブジェクトとしたnew_my_objectオブジェクトを生成
+    const new_my_object = Object.create(my_object);
+    expect(new_my_object.name()).toBe('まいおぶじぇくと');
+    expect(new_my_object.__proto__.name()).toBe('まいおぶじぇくと');
+  });
+});
+

--- a/spec/string.spec.js
+++ b/spec/string.spec.js
@@ -1,0 +1,44 @@
+/*
+ * Arrayクラスの挙動を覚える
+ */
+
+describe('String', () => {
+  describe('定義方法', () => {
+    it('バッククォート(\)で改行できる', () => {
+      const text1 = `文字列1
+です。`;
+      const text2 = `文字列2
+      です。`;
+
+      expect(text1).toBe('文字列1\nです。');
+      expect(text2).toBe('文字列2\n      です。');
+    });
+
+
+    it('バッククォート(\)と${}でインライン展開できる', () => {
+      const subject = 'インライン展開';
+      const text1 = `${subject}できる`;
+      const text2 = "${subject}できない";
+
+      expect(text1).toEqual('インライン展開できる');
+      expect(text2).toEqual('${subject}できない');
+    });
+
+    it('スラッシュ(/)でエスケープできる', () => {
+      const text = "エスケープシーケンス\"";
+      expect(text).toBe('エスケープシーケンス"');
+    });
+  });
+
+  describe('文字列の分解(split)と結合(join)', () => {
+    it('テスト', () => {
+      const text = "1-2-3";
+      expect(text.split('-')).toEqual(['1', '2', '3']);
+
+      const numbers = ['1', '2', '3'];
+      expect(numbers.join(',')).toEqual('1,2,3');
+    });
+  });
+
+  describe 
+});

--- a/spec/this.spec.js
+++ b/spec/this.spec.js
@@ -1,0 +1,19 @@
+// thisがどの値を参照するかは実行時に決まるため、
+// 変数の代入などによって意図しないベースオブジェクトに変わる場合がある。
+// この挙動によって扱いづらい場合があるので、callメソッドなどを使ってthisを指定して関数を呼び出すのが安全です。
+describe('this', () => {
+  it('基本はレシーバーを返す', () => {
+    const obj = {
+      name: 'thisさん',
+      method1() { return this },
+      method2() { return this.name },
+    };
+    expect(obj.method1()).toBe(obj);
+    expect(obj.method2()).toBe(obj.name);
+  });
+
+  it('レシーバーがない場合はundefinedを返す', () => {
+    const func = () => { return this };
+    expect(func()).toBe(undefined);
+  });
+});


### PR DESCRIPTION
## 概要
このPRでやっていることは表題の通り。

## なぜJestに残すのか？
WEB+DB PRESS(vol 129)の「第1回　サバンナ便り　学習用テスト」より、
学びの効果を高めるには「実際に手を動かすこと」と「即時性のあるフィードバックが得られる時」が重要であると記載されており、学習用テストは上記を満たすことが可能なため実践してみる。

また、テストが落ちた際に気付ける仕組みを導入することで、処理の仕様が変わったことも検知ができるので良いことづくしであるため、Jestに残していく。